### PR TITLE
Hide docs that can’t show up in the navigation

### DIFF
--- a/can-validate.js
+++ b/can-validate.js
@@ -22,6 +22,7 @@ var Validate = {
 	* ```
 	* @param {string} id The key name of the validator library.
 	* @param {object|function} validator The validator libarary. Only pass instances.
+	* @hide
 	*/
 	validator: function () {
 		return this._validators[this._validatorId];
@@ -35,6 +36,7 @@ var Validate = {
 	* ```
 	* @param {string} id The key name of the validator library.
 	* @param {object|function} validator The validator libarary. Only pass instances.
+	* @hide
 	*/
 	register: function (id, validator) {
 		this._validatorId = id;
@@ -51,6 +53,7 @@ var Validate = {
 	* @param {object} options Validation config object, structure depends on the
 	*  validation library used.
 	* @param {string} name Optional. The key name of the value.
+	* @hide
 	*/
 	isValid: function () {
 		//!steal-remove-start
@@ -71,6 +74,7 @@ var Validate = {
 	* @param {object} options Validation config object, structure depends on the
 	*  validation library used.
 	* @param {string} name Optional. The key name of the value.
+	* @hide
 	*/
 	once: function () {
 		//!steal-remove-start
@@ -88,6 +92,7 @@ var Validate = {
 	* @param {object} values A map of the different objects to validate.
 	* @param {object} options Validation config object, structure depends on the
 	*  validation library used.
+	* @hide
 	*/
 	validate: function () {
 		var validateArgs = arguments;

--- a/map/validate/validate.js
+++ b/map/validate/validate.js
@@ -151,6 +151,7 @@ $.extend(Map.prototype, {
 
 	/**
 	* @function _validate _Validate
+	* @hide
 	* @description Runs validation on the entire map instance. Actual behavior of
 	* "validate all" is defined by the registered shim (`validate`).
 	*/
@@ -175,6 +176,7 @@ $.extend(Map.prototype, {
 	},
 	/**
 	* @function _validateOne Validate One
+	* @hide
 	* @description Main method used by `Map.define` setter when a property changes.
 	*  Runs validation on a property. Actual behavior of "validate one" is defined
 	*  by the registered shim (`once`).
@@ -221,6 +223,7 @@ $.extend(Map.prototype, {
 
 	/**
 	* @function _processValidateOpts Process Validate Opts
+	* @hide
 	* @description Allows the ability to pass computes in validation properties,
 	* this allows for things like making a property required based on the value on
 	* another property.


### PR DESCRIPTION
All of these docs should probably be exposed, but for now they’re being hidden because they can’t be navigated to with how they’re documented now.

Part of https://github.com/canjs/canjs/issues/3660