### PR TITLE
Pin validate.js to <0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
   "homepage": "https://github.com/canjs/can-validate-legacy",
   "devDependencies": {
     "bit-docs": "0.0.7",
-    "can-compute": "^3.1.0-pre.11",
-    "can-map": "^3.1.0-pre.11",
-    "can-map-define": "^3.1.0-pre.1",
-    "can-stache": "^3.1.0-pre.5",
+    "can-compute": "^3.1.0",
+    "can-map": "^3.1.0",
+    "can-map-define": "^3.1.0",
+    "can-stache": "^3.1.0",
     "detect-cyclic-packages": "^1.1.0",
     "jquery": "^3.1.1",
     "jshint": "^2.9.1",
@@ -70,7 +70,7 @@
     }
   },
   "dependencies": {
-    "can-util": "^3.9.0-pre.4",
-    "validate.js": "^0.12.0"
+    "can-util": "^3.9.0",
+    "validate.js": "<0.12.0"
   }
 }


### PR DESCRIPTION
0.12 seems to introduce changes that break the tests.