### PR TITLE
upgrade can packages to 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,8 @@
   "homepage": "https://github.com/canjs/can-validate-legacy",
   "devDependencies": {
     "bit-docs": "0.0.7",
-    "can-compute": "^3.1.0",
-    "can-map": "^3.1.0",
-    "can-map-define": "^3.1.0",
-    "can-stache": "^3.1.0",
+    "can-map-define": "^4.3.3",
+    "can-stache": "^4.10.4",
     "detect-cyclic-packages": "^1.1.0",
     "jquery": "^3.1.1",
     "jshint": "^2.9.1",
@@ -71,7 +69,9 @@
   },
   "dependencies": {
     "can-assign": "^1.1.1",
+    "can-compute": "^4.1.0",
     "can-log": "<2.0.0",
+    "can-map": "^4.1.2",
     "can-namespace": "<2.0.0",
     "can-reflect": "^1.0.0",
     "validate.js": "<0.12.0"


### PR DESCRIPTION
This allows can-validate-legacy to work with CanJS 4.x

closes #54 